### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Deafult
+* @JonasFranke


### PR DESCRIPTION
This pull request includes a small change to the `CODEOWNERS` file. The change assigns default ownership to Jonas Franke.

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR1-R2): Added Jonas Franke as the default owner for all files.