### PR TITLE
199 config not found when starting server the first time

### DIFF
--- a/src/main/java/de/j/stationofdoom/main/Main.java
+++ b/src/main/java/de/j/stationofdoom/main/Main.java
@@ -68,7 +68,6 @@ public final class Main extends JavaPlugin {
     @Override
     public void onEnable() {
         Config config = Config.getInstance();
-        //saveDefaultConfig();
         config.initializeConfig();
         Database database = Database.getInstance();
         database.initDatabase();

--- a/src/main/java/de/j/stationofdoom/main/Main.java
+++ b/src/main/java/de/j/stationofdoom/main/Main.java
@@ -68,7 +68,7 @@ public final class Main extends JavaPlugin {
     @Override
     public void onEnable() {
         Config config = Config.getInstance();
-        saveDefaultConfig();
+        //saveDefaultConfig();
         config.initializeConfig();
         Database database = Database.getInstance();
         database.initDatabase();


### PR DESCRIPTION
## Describe your changes

<!-- If your changes resolve an open issue, please make sure to note that here using a GitHub keyword (https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue) -- e.g. resolves #123 -->

...

## Notes for testing your change

...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Removed automatic saving of default configuration during plugin initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->